### PR TITLE
Increase Page Size for MD Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,36 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Increased page size for MD query
+
 ## [1.0.0] - 2020-04-03
+
 ### Changed
+
 - Remove organization assignment status
 - Delete organization assignment on leave
 - Update `approved` status on `CL` on create or delete users
 
 ### Fixed
+
 - Fix create organization not showing for admin users issue
 
 ## [1.0.0] - 2020-03-18
+
 ### Fixed
+
 - Fixed CSS handles typing issue
 - Fixed linting issues 
 
 ### Added
+
 - Added functionality to transfer admin privilege (only admin users can transfer his privilege to others)
 - Added `organization` and `isOrgAdmin` columns to `CL` master data table
 
 ### Changed
+
 - Show notification if user is already assigned to some other organization
 - Create organization assignment with `APPROVED` status 
 - Add checkbox to change `isOrgAdmin` in Add and Edit users in organization
@@ -34,19 +45,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rename schema `organization-assignment-schema-v1` to `user-organization-schema-v1`
 
 ### Removed
+
 - Removed `persona` entity
 - Remove pending organization request feature
 
 
 ## [0.0.3] - 2020-02-28
+
 ### Added
+
 - Auto reload until changes reflect on the web page
 - Use `document-graphql` application to query master data instead of `vtex.store-graphql` application
 
 ## [0.0.2] - 2020-02-13
 
 ## [0.0.1] - 2020-02-13
+
 ### Added
+
 - Delete, edit and reinvite users in organization functionality
 - Approve and reject user pending requests
 - Add users to the organization functionality

--- a/react/components/AddOrganization.tsx
+++ b/react/components/AddOrganization.tsx
@@ -233,6 +233,7 @@ const AddOrganization = ({
       fields: BUSINESS_ROLE_FIELDS,
       where: '(name=*manager*)',
       schema: BUSINESS_ROLE_SCHEMA,
+      pageSize: 1000,
     },
   })
 

--- a/react/components/DefaultAssignmentInfo.tsx
+++ b/react/components/DefaultAssignmentInfo.tsx
@@ -100,6 +100,7 @@ const DefaultAssignmentInfo = ({
           acronym: CLIENT_ACRONYM,
           fields: CLIENT_FIELDS,
           where: `(organizationId=${orgId})`,
+          pageSize: 1000,
         },
         fetchPolicy: 'no-cache',
       })
@@ -219,6 +220,7 @@ const DefaultAssignmentInfo = ({
           schema: ORG_ASSIGNMENT_SCHEMA,
           fields: ORG_ASSIGNMENT_FIELDS,
           where: `(businessOrganizationId=${orgId})`,
+          pageSize: 1000,
         },
         fetchPolicy: 'no-cache',
       })

--- a/react/components/MyOrganization.tsx
+++ b/react/components/MyOrganization.tsx
@@ -76,6 +76,7 @@ const MyOrganization = ({ intl }: Props) => {
           acronym: CLIENT_ACRONYM,
           fields: CLIENT_FIELDS,
           where: `email=${email}`,
+          pageSize: 1000,
         },
         fetchPolicy: 'no-cache',
       })
@@ -93,6 +94,7 @@ const MyOrganization = ({ intl }: Props) => {
               schema: ORG_ASSIGNMENT_SCHEMA,
               fields: ORG_ASSIGNMENT_FIELDS,
               where: `email=${email}`,
+              pageSize: 1000,
             },
             fetchPolicy: 'no-cache',
           })
@@ -123,6 +125,7 @@ const MyOrganization = ({ intl }: Props) => {
               schema: ORG_ASSIGNMENT_SCHEMA,
               fields: ORG_ASSIGNMENT_FIELDS,
               where: `(businessOrganizationId=${organizationIdData} AND status=${ORG_ASSIGNMENT_STATUS_APPROVED})`,
+              pageSize: 1000,
             },
             fetchPolicy: 'no-cache',
           })
@@ -142,6 +145,7 @@ const MyOrganization = ({ intl }: Props) => {
             acronym: BUSINESS_ROLE,
             schema: BUSINESS_ROLE_SCHEMA,
             fields: BUSINESS_ROLE_FIELDS,
+            pageSize: 1000,
           },
           fetchPolicy: 'no-cache',
         })

--- a/react/components/MyUsers.tsx
+++ b/react/components/MyUsers.tsx
@@ -72,6 +72,7 @@ const MyUsers = ({
       acronym: BUSINESS_ROLE,
       fields: BUSINESS_ROLE_FIELDS,
       schema: BUSINESS_ROLE_SCHEMA,
+      pageSize: 1000,
     },
   })
   const { data: orgAssignments } = useQuery(documentQuery, {
@@ -81,6 +82,7 @@ const MyUsers = ({
       fields: ORG_ASSIGNMENT_FIELDS,
       where: `businessOrganizationId=${organizationId}`,
       schema: ORG_ASSIGNMENT_SCHEMA,
+      pageSize: 1000,
     },
   })
 
@@ -122,6 +124,7 @@ const MyUsers = ({
             acronym: CLIENT_ACRONYM,
             fields: CLIENT_FIELDS,
             where: `email=${assignment.email}`,
+            pageSize: 1000,
           },
         })
       })

--- a/react/components/UserListItem.tsx
+++ b/react/components/UserListItem.tsx
@@ -32,6 +32,7 @@ const UserListItem = ({
       acronym: CLIENT_ACRONYM,
       fields: CLIENT_FIELDS,
       where: `email=${orgAssignment.email}`,
+      pageSize: 1000,
     },
   })
 

--- a/react/components/modals/AddUser.tsx
+++ b/react/components/modals/AddUser.tsx
@@ -245,6 +245,7 @@ const AddUser = ({
             acronym: CLIENT_ACRONYM,
             fields: CLIENT_FIELDS,
             where: `email=${state.email}`,
+            pageSize: 1000,
           },
           fetchPolicy: 'no-cache',
         })

--- a/react/components/modals/UserEditModal.tsx
+++ b/react/components/modals/UserEditModal.tsx
@@ -59,6 +59,7 @@ const UserEditModal = ({
       acronym: CLIENT_ACRONYM,
       fields: CLIENT_FIELDS,
       where: `email=${email}`,
+      pageSize: 1000,
     },
   })
 

--- a/react/utils/cacheUtils.ts
+++ b/react/utils/cacheUtils.ts
@@ -18,6 +18,7 @@ const userListArgs = (orgId: string) => {
       fields: ORG_ASSIGNMENT_FIELDS,
       where: `businessOrganizationId=${orgId}`,
       schema: ORG_ASSIGNMENT_SCHEMA,
+      pageSize: 1000,
     },
   }
 }
@@ -36,6 +37,7 @@ const clientListArgs = (email: string) => {
       acronym: CLIENT_ACRONYM,
       fields: CLIENT_FIELDS,
       where: `email=${email}`,
+      pageSize: 1000,
     },
   }
 }


### PR DESCRIPTION
#### What does this PR do? \*

This PR increases the page size for Master Data (V2) queries, as a temporary fix for having an undefined default organization assignment.

#### How to test it? \*

Visit the **my organizations** page as a logged in user and you should be able to see the list of users with your organization details.

#### Describe alternatives you've considered, if any. \*

Since this fix will break at some point (with the growing number of records), each usage of the MD query has to be handled differently (with changes to the logic).