### PR TITLE
Organization users pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Users list pagination
+
+### Fixed
+- Organization page not loading issue fixed
+
 ## [1.0.0] - 2020-04-03
 ### Changed
 - Remove organization assignment status

--- a/messages/context.json
+++ b/messages/context.json
@@ -67,5 +67,6 @@
   "store/my-users.my-organization.organization.returnBtn.text": "RETURN",
   "store/my-users.my-organization.status.approved": "Approved",
   "store/my-users.my-organization.status.not-approved": "Not Approved",
-  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin"
+  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin",
+  "store/my-users.my-organization.showMore": "Show More"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -67,5 +67,6 @@
   "store/my-users.my-organization.organization.returnBtn.text": "RETURN",
   "store/my-users.my-organization.status.approved": "Approved",
   "store/my-users.my-organization.status.not-approved": "Not Approved",
-  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin"
+  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin",
+  "store/my-users.my-organization.showMore": "Show More"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -67,5 +67,6 @@
   "store/my-users.my-organization.organization.returnBtn.text": "RETURN",
   "store/my-users.my-organization.status.approved": "Approved",
   "store/my-users.my-organization.status.not-approved": "Not Approved",
-  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin"
+  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin",
+  "store/my-users.my-organization.showMore": "Show More"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -67,5 +67,6 @@
   "store/my-users.my-organization.organization.returnBtn.text": "RETURN",
   "store/my-users.my-organization.status.approved": "Approved",
   "store/my-users.my-organization.status.not-approved": "Not Approved",
-  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin"
+  "store/my-users.my-organization.status.isOrgAdmin": "Organization Admin",
+  "store/my-users.my-organization.showMore": "Show More"
 }

--- a/react/components/MyUsers.tsx
+++ b/react/components/MyUsers.tsx
@@ -44,7 +44,7 @@ const MyUsers = ({
   intl,
 }: Props) => {
   const PAGE_SIZE_STEPPER = 10
-  const [assignmentsPageSize, setAssignmentsPageSize] = useState(10)
+  const [assignmentsPageSize, setAssignmentsPageSize] = useState(PAGE_SIZE_STEPPER)
 
   const [updateDocument] = useMutation(UPDATE_DOCUMENT)
   const [deleteDocument] = useMutation(DELETE_DOCUMENT, {
@@ -278,7 +278,9 @@ const MyUsers = ({
             size="small" 
             onClick={loadMoreAssignments}
             isLoading={loadingAssignments}
-            >Show More</Button> : <div />
+            >{intl.formatMessage({
+              id: 'store/my-users.my-organization.showMore',
+            })}</Button> : <div />
           }
         </div>
         <UserConfirmationModal

--- a/react/components/MyUsers.tsx
+++ b/react/components/MyUsers.tsx
@@ -43,6 +43,9 @@ const MyUsers = ({
   showToast,
   intl,
 }: Props) => {
+  const PAGE_SIZE_STEPPER = 10
+  const [assignmentsPageSize, setAssignmentsPageSize] = useState(10)
+
   const [updateDocument] = useMutation(UPDATE_DOCUMENT)
   const [deleteDocument] = useMutation(DELETE_DOCUMENT, {
     update: (cache: any, { data }: any) =>
@@ -74,12 +77,24 @@ const MyUsers = ({
       schema: BUSINESS_ROLE_SCHEMA,
     },
   })
-  const { data: orgAssignments } = useQuery(documentQuery, {
+  const { data: orgAssignments, loading: loadingAssignments } = useQuery(documentQuery, {
     skip: organizationId == '',
     variables: {
       acronym: ORG_ASSIGNMENT,
       fields: ORG_ASSIGNMENT_FIELDS,
       where: `businessOrganizationId=${organizationId}`,
+      schema: ORG_ASSIGNMENT_SCHEMA,
+      page: 1,
+      pageSize: assignmentsPageSize
+    },
+  })
+
+  const { data: defaultAssignmentData } = useQuery(documentQuery, {
+    skip: organizationId == '',
+    variables: {
+      acronym: ORG_ASSIGNMENT,
+      fields: ORG_ASSIGNMENT_FIELDS,
+      where: `businessOrganizationId=${organizationId} AND email=${email}`,
       schema: ORG_ASSIGNMENT_SCHEMA,
     },
   })
@@ -92,13 +107,18 @@ const MyUsers = ({
     value: role.id,
     name: role.name,
   }))
+
   const assignments: OrganizationAssignment[] = documentSerializer(
     pathOr([], ['myDocuments'], orgAssignments)
   )
 
-  const defaultUserAssignment: OrganizationAssignment = find(
+  const defaultAssignment: OrganizationAssignment[] = documentSerializer(
+    pathOr([], ['myDocuments'], defaultAssignmentData)
+  )
+
+  const defaultUserAssignment = find(
     propEq('email', email),
-    assignments
+    defaultAssignment
   ) as OrganizationAssignment
 
   const deleteOrgAssignment = (assignment: OrganizationAssignment) => {
@@ -204,7 +224,11 @@ const MyUsers = ({
     setIsAddNewUserOpen(false)
   }
 
-  return (
+  const loadMoreAssignments = () => {
+    setAssignmentsPageSize(assignmentsPageSize + PAGE_SIZE_STEPPER)
+  }
+
+  return defaultUserAssignment? (
     <div className="flex flex-column pa5">
       <div className="flex-row">
         <div className="fl pr2">
@@ -247,6 +271,16 @@ const MyUsers = ({
             )}
           </div>
         </div>
+        <div className="flex justify-center">
+          {
+            loadingAssignments || assignments.length >= assignmentsPageSize ? 
+            <Button 
+            size="small" 
+            onClick={loadMoreAssignments}
+            isLoading={loadingAssignments}
+            >Show More</Button> : <div />
+          }
+        </div>
         <UserConfirmationModal
           isOpen={isDeleteConfirmationOpen}
           isLoading={deleteConfirmationLoading}
@@ -283,7 +317,7 @@ const MyUsers = ({
         />
       </div>
     </div>
-  )
+  ): <div />
 }
 
 export default injectIntl(MyUsers)


### PR DESCRIPTION
#### What does this PR do?
Master data default page size is 15 so all the users in organization are not displayed.

Issue Fixed: When the organization has more than 15 users and someone edited their profile, natural order of master data entries gets changed so it throws an error finding default organization.

Feature: Implement pagination for users in organization

#### How to test it? 
You can see the pagination in the screenshot
![image](https://user-images.githubusercontent.com/60665590/89799409-1041cf80-db4b-11ea-84fd-3341a4081445.png)

you can check the [demo](https://demo--b2bstore.myvtex.com/account#/users) workspace in b2bstore by sign in as "Fernando"
