### PR TITLE
fix: adding e-mail of user on modal confimartion

### DIFF
--- a/react/components/modals/UserConfirmationModal.tsx
+++ b/react/components/modals/UserConfirmationModal.tsx
@@ -43,9 +43,7 @@ const UserConfirmationModal = ({
       <div className="flex flex-column mb5 mt5">
         <div>
           <span>{message}</span>
-          <span className="b">
-            {pathOr('', ['personaId_linked', 'email'], assignment)}
-          </span>
+          <span className="b">{pathOr('', ['email'], assignment)}</span>
         </div>
       </div>
     </ModalDialog>


### PR DESCRIPTION
#### What does this PR do? \*

The user's email is not being displayed, this modification solves this

#### How to test it? \*

1 - https://{workspace}--{account}.myvtex.com/account#/users

2 - Select an user and click in "delete".

3 - The user's e-mail must appears on modal


#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
